### PR TITLE
Check for an existing data listing before attempting to add one

### DIFF
--- a/SVD-Loader.py
+++ b/SVD-Loader.py
@@ -16,6 +16,7 @@ from ghidra.program.model.mem import MemoryBlockType
 from ghidra.program.model.address import AddressFactory
 from ghidra.program.model.symbol import SourceType
 from ghidra.program.model.mem import MemoryConflictException
+from ghidra.program.model.util import CodeUnitInsertionException
 
 class MemoryRegion:
 	def __init__(self, name, start, end):
@@ -96,6 +97,7 @@ print("Generating memory regions...")
 # First, we need to generate a list of memory regions.
 # This is because some SVD files have overlapping peripherals...
 memory_regions = []
+alt_peripherals = []
 for peripheral in peripherals:
 	start = peripheral.base_address
 	length = peripheral.address_block.offset + peripheral.address_block.size
@@ -162,11 +164,14 @@ for peripheral in peripherals:
 
 	dtm.addDataType(peripheral_struct, DataTypeConflictHandler.REPLACE_HANDLER)
 
-	listing.createData(addr, peripheral_struct, False)
+	try:
+		listing.createData(addr, peripheral_struct, False)
+	except CodeUnitInsertionException:
+		continue
 
 	symtbl.createLabel(addr,
 					peripheral.name,
 					namespace,
-					SourceType.USER_DEFINED );
+					SourceType.USER_DEFINED )
 	# except:
 	# 	print("\t\tFailed to generate peripheral " + peripheral.name)


### PR DESCRIPTION
When attempting to apply an SVD to a Nordic nRF52, the loader fails due to conflicting data at some of the peripheral addresses.  Turns out that Nordic lists multiple peripherals as having the same base address and (I think) allows one to switch between them based on context or something.  In any case, checking for an existing data listing before adding one fixes this.  

Resulting listing view:


![Result](https://user-images.githubusercontent.com/14313854/82127126-4b687880-977f-11ea-8c08-24c738455ee3.PNG)
