### PR TITLE
Import sys so the sys.exit() calls in error cases don't crash

### DIFF
--- a/SVD-Loader.py
+++ b/SVD-Loader.py
@@ -9,6 +9,7 @@
 # https://leveldown.de/blog/svd-loader/
 # License: GPLv3
 
+import sys
 from cmsis_svd.parser import SVDParser
 from ghidra.program.model.data import Structure, StructureDataType, UnsignedIntegerDataType, DataTypeConflictHandler
 from ghidra.program.model.data import UnsignedShortDataType, ByteDataType, UnsignedLongLongDataType


### PR DESCRIPTION
If the CPU isn't a Cortex-M or isn't little-endian, we call `sys.exit()`, but we currently never import `sys`.