### PR TITLE
README update for cmsis-svd/cmsis-svd-data URL and SVD number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The script can be found in the `leveldown security` folder in Ghidra's Script Ma
 
 ## Getting SVDs
 
-- [cmsis-svd contains over 650 SVDs](https://github.com/posborne/cmsis-svd/)
+- [cmsis-svd-data contains over 1903 SVDs](https://github.com/cmsis-svd/cmsis-svd-data)
 - [Keil Software Packs](https://www.keil.com/pack)
 
 ## Credits


### PR DESCRIPTION
Hello,

Since I am part of the core maintainers of the cmsis-svd project I propose this little README update, in order to have more visibility through your repository.

Also, we have move the data directory of  the https://github.com/posborne/cmsis-svd/ repository to the https://github.com/cmsis-svd/cmsis-svd-data repository after the migration of the posborne/cmsis-svd project to the https://github.com/cmsis-svd Github organisation.

